### PR TITLE
Detect port on MacOS using lsof

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ connections, if you are using it with other db please let me know.
   - **NeoVim** - Plugin is using nvim's `jobstart()` API to create and keep
     tunnel, I'm sure it can be done for Vim 8+ as well. I would be grateful
     for PR :heart:
-  - **Linux** (Maybe MacOS ?) - adapter is using `ssh` command to connect to
+  - **Linux** or **MacOS** - adapter is using `ssh` command to connect to
     the remote server. It is also using following commands:
-    `netstat`, `grep`, `awk` and `sed`. To be more specific this command is
+    `netstat` (Linux), `lsof` (MacOS), `grep`, `awk` and `sed`. To be more specific this command is
     used:
-    `netstat -tuplen 2>/dev/null | grep {localhost} | awk '{print $4}' | sed 's/.*://g'`
+    `netstat -tuplen 2>/dev/null | grep {localhost} | awk '{print $4}' | sed 's/.*://g'` (Linux)
+    `lsof -nP -iTCP -sTCP:LISTEN 2>/dev/null | grep {localhost} | awk '{print $9}' | sed 's/.*://g'` (MacOS)
 
 ## Installation
 

--- a/autoload/db/adapter/ssh.vim
+++ b/autoload/db/adapter/ssh.vim
@@ -22,8 +22,8 @@ let s:default_ports = {
 let s:default_async = get(g:, 'db_ssh_default_async', v:false)
 
 function s:get_free_port()
-  let ports = systemlist("netstat -tuplen 2>/dev/null | grep " . s:localhost
-      \                . " | awk '{print $4}' | sed 's/.*://g'")
+  let ports = systemlist("lsof -nP -iTCP -sTCP:LISTEN | grep " . s:localhost
+      \                . " | awk '{print $9}' | sed 's/.*://g'")
 
   for port in s:port_range
       if index(ports, "" . port) == -1

--- a/autoload/db/adapter/ssh.vim
+++ b/autoload/db/adapter/ssh.vim
@@ -25,7 +25,7 @@ function s:get_free_port()
   let env = toupper(substitute(system('uname'), '\n', '', ''))
 
   let detect_open_port_cmd = env =~ 'DARWIN'
-      \ ? ("lsof -nP -iTCP -sTCP:LISTEN | grep " . s:localhost . " | awk '{print $9}' | sed 's/.*://g'")
+      \ ? ("lsof -nP -iTCP -sTCP:LISTEN 2>/dev/null | grep " . s:localhost . " | awk '{print $9}' | sed 's/.*://g'")
       \ : ("netstat -tuplen 2>/dev/null | grep " . s:localhost . " | awk '{print $4}' | sed 's/.*://g'")
 
   let ports = systemlist(detect_open_port_cmd)

--- a/autoload/db/adapter/ssh.vim
+++ b/autoload/db/adapter/ssh.vim
@@ -22,8 +22,13 @@ let s:default_ports = {
 let s:default_async = get(g:, 'db_ssh_default_async', v:false)
 
 function s:get_free_port()
-  let ports = systemlist("lsof -nP -iTCP -sTCP:LISTEN | grep " . s:localhost
-      \                . " | awk '{print $9}' | sed 's/.*://g'")
+  let env = toupper(substitute(system('uname'), '\n', '', ''))
+
+  let detect_open_port_cmd = env =~ 'DARWIN'
+      \ ? ("lsof -nP -iTCP -sTCP:LISTEN | grep " . s:localhost . " | awk '{print $9}' | sed 's/.*://g'")
+      \ : ("netstat -tuplen 2>/dev/null | grep " . s:localhost . " | awk '{print $4}' | sed 's/.*://g'")
+
+  let ports = systemlist(detect_open_port_cmd)
 
   for port in s:port_range
       if index(ports, "" . port) == -1


### PR DESCRIPTION
As discussed in #5, here is a solution proposal.

I use `lsof` to detect the open ports on MacOS. I still keep the use of `netstat` for other OSes.

Let me know if this works for you, or if you need anything else in the PR.

Fixes: #5 